### PR TITLE
fix: restrict CORS headers to specific API endpoint

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -9,7 +9,7 @@ restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
 
 [[headers]]
-for = "/*"
+for = "/api/generate"
 [headers.values]
 Access-Control-Allow-Origin = "https://vakac995.github.io"
 Access-Control-Allow-Methods = "*"


### PR DESCRIPTION
This pull request includes a change to the `railway.toml` file that updates the header configuration for API requests.

Configuration updates:

* [`railway.toml`](diffhunk://#diff-eb56cd74597c2adea0ebd0dfd5ba2f6e4f4e97417e35c8cecc87f598c47b5bb1L12-R12): Changed the `for` field in the `headers` section from `"/*"` to `"/api/generate"`, restricting the headers configuration to apply only to API generation requests.